### PR TITLE
Force set JAVA_HOME

### DIFF
--- a/jmeter-wrapper.sh
+++ b/jmeter-wrapper.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 JRE_HOME="/app/jre"
+JAVA_HOME="$JRE_HOME"
+export JAVA_HOME
 export JRE_HOME
 
 # Workarround for Flatpak <1.13


### PR DESCRIPTION
Set JAVA_HOME as well as JRE_HOME to avoid external environment issues.

Reported in issue #3 