### PR TITLE
Add help metadata

### DIFF
--- a/org.apache.jmeter.Help.metainfo.xml
+++ b/org.apache.jmeter.Help.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.apache.jmeter.Help</id>
+  <extends>org.apache.jmeter</extends>
+  <name>Apache JMeter help files</name>
+  <summary>Optional help files for Apache JMeter help files</summary>
+  <url type="homepage">https://jmeter.apache.org/</url>
+  <url type="help">https://jmeter.apache.org/usermanual/index.html</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+</component>

--- a/org.apache.jmeter.yaml
+++ b/org.apache.jmeter.yaml
@@ -34,11 +34,14 @@ modules:
       - install -Dpm644 -T docs/images/jmeter_square.png /app/share/icons/hicolor/256x256/apps/org.apache.jmeter.png
       - install -Dpm644 -T docs/images/jmeter_square.svg /app/share/icons/hicolor/scalable/apps/org.apache.jmeter.svg
       - install -Dpm644 -t /app/share/applications org.apache.jmeter.desktop
-      - install -Dpm644 -t /app/share/metainfo org.apache.jmeter.metainfo.xml
         # Copy User Manual
       - mv printable_docs/usermanual docs/
       - cp -R docs /app/
       - ln -s docs /app/printable_docs
+    post-install:
+      - install -Dpm644 -t /app/share/metainfo org.apache.jmeter.metainfo.xml
+      - install -Dpm644 -t /app/docs/share/metainfo org.apache.jmeter.Help.metainfo.xml
+      - appstream-compose --basename=org.apache.jmeter.Help --prefix=/app/docs --origin=flatpak org.apache.jmeter.Help
     cleanup:
       - /bin/*.bat
       - /bin/*.cmd
@@ -67,3 +70,5 @@ modules:
         path: org.apache.jmeter.desktop
       - type: file
         path: org.apache.jmeter.metainfo.xml
+      - type: file
+        path: org.apache.jmeter.Help.metainfo.xml

--- a/org.apache.jmeter.yaml
+++ b/org.apache.jmeter.yaml
@@ -29,19 +29,19 @@ modules:
   - name: JMeter
     buildsystem: simple
     build-commands:
-      - cp -R bin lib /app/
-      - install -Dpm755 -t /app/bin jmeter-wrapper.sh
-      - install -Dpm644 -T docs/images/jmeter_square.png /app/share/icons/hicolor/256x256/apps/org.apache.jmeter.png
-      - install -Dpm644 -T docs/images/jmeter_square.svg /app/share/icons/hicolor/scalable/apps/org.apache.jmeter.svg
-      - install -Dpm644 -t /app/share/applications org.apache.jmeter.desktop
+      - cp -R bin lib ${FLATPAK_DEST}/
+      - install -Dpm755 -t ${FLATPAK_DEST}/bin jmeter-wrapper.sh
+      - install -Dpm644 -T docs/images/jmeter_square.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
+      - install -Dpm644 -T docs/images/jmeter_square.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dpm644 -t ${FLATPAK_DEST}/share/applications ${FLATPAK_ID}.desktop
         # Copy User Manual
       - mv printable_docs/usermanual docs/
-      - cp -R docs /app/
-      - ln -s docs /app/printable_docs
+      - cp -R docs ${FLATPAK_DEST}/
+      - ln -s docs ${FLATPAK_DEST}/printable_docs
     post-install:
-      - install -Dpm644 -t /app/share/metainfo org.apache.jmeter.metainfo.xml
-      - install -Dpm644 -t /app/docs/share/metainfo org.apache.jmeter.Help.metainfo.xml
-      - appstream-compose --basename=org.apache.jmeter.Help --prefix=/app/docs --origin=flatpak org.apache.jmeter.Help
+      - install -Dpm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
+      - install -Dpm644 -t ${FLATPAK_DEST}/docs/share/metainfo ${FLATPAK_ID}.Help.metainfo.xml
+      - appstream-compose --basename=${FLATPAK_ID}.Help --prefix=${FLATPAK_DEST}/docs --origin=flatpak ${FLATPAK_ID}.Help
     cleanup:
       - /bin/*.bat
       - /bin/*.cmd

--- a/org.apache.jmeter.yaml
+++ b/org.apache.jmeter.yaml
@@ -16,7 +16,7 @@ finish-args:
 
 add-extensions:
   org.apache.jmeter.Help:
-    directory: docs
+    directory: share/doc/jmeter
     bundle: true
     autodelete: true
 
@@ -35,27 +35,28 @@ modules:
       - install -Dpm644 -T docs/images/jmeter_square.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dpm644 -t ${FLATPAK_DEST}/share/applications ${FLATPAK_ID}.desktop
         # Copy User Manual
-      - mv printable_docs/usermanual docs/
-      - cp -R docs ${FLATPAK_DEST}/
-      - ln -s docs ${FLATPAK_DEST}/printable_docs
+      - mkdir -p ${FLATPAK_DEST}/share/doc/jmeter/printable_docs
+      - cp -R printable_docs/usermanual ${FLATPAK_DEST}/share/doc/jmeter/printable_docs/
+      - cp -R docs ${FLATPAK_DEST}/share/doc/jmeter/
+      - ln -s share/doc/jmeter/{docs,printable_docs} ${FLATPAK_DEST}/
     post-install:
       - install -Dpm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
-      - install -Dpm644 -t ${FLATPAK_DEST}/docs/share/metainfo ${FLATPAK_ID}.Help.metainfo.xml
-      - appstream-compose --basename=${FLATPAK_ID}.Help --prefix=${FLATPAK_DEST}/docs --origin=flatpak ${FLATPAK_ID}.Help
+      - install -Dpm644 -t ${FLATPAK_DEST}/share/doc/jmeter/share/metainfo ${FLATPAK_ID}.Help.metainfo.xml
+      - appstream-compose --basename=${FLATPAK_ID}.Help --prefix=${FLATPAK_DEST}/share/doc/jmeter --origin=flatpak ${FLATPAK_ID}.Help
     cleanup:
       - /bin/*.bat
       - /bin/*.cmd
       - /bin/*.bshrc
       - /bin/examples
         # Clean docs
-      - /docs/.htaccess
-      - /docs/api
-      - /docs/images/favicon.*
-      - /docs/images/apple-touch-icon.png
-      - /docs/images/mstile-*.png
-      - /docs/images/jmeter_square.*
-      - /docs/images/screenshoots/changes
-      - /docs/usermanual/*.pdf
+      - /share/doc/jmeter/docs/.htaccess
+      - /share/doc/jmeter/docs/api
+      - /share/doc/jmeter/docs/images/favicon.*
+      - /share/doc/jmeter/docs/images/apple-touch-icon.png
+      - /share/doc/jmeter/docs/images/mstile-*.png
+      - /share/doc/jmeter/docs/images/jmeter_square.*
+      - /share/doc/jmeter/docs/images/screenshots/changes
+      - /share/doc/jmeter/printable_docs/usermanual/*.pdf
     sources:
       - type: archive
         url: https://dlcdn.apache.org//jmeter/binaries/apache-jmeter-5.6.2.tgz


### PR DESCRIPTION
- Fix JMeter Help extension metadata.
- Move extension mount path.
