### PR TITLE
Fix max rhino version

### DIFF
--- a/org.apache.jmeter.yaml
+++ b/org.apache.jmeter.yaml
@@ -73,6 +73,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 229008
+          versions: {<: 1.8.0}
           url-template: https://repo1.maven.org/maven2/org/mozilla/rhino-engine/$version/rhino-engine-$version.jar
 
   - name: metadata


### PR DESCRIPTION
Fix max rhino version to match the same as inside JMeter.

Inside JMeter currently the rhino jar is at 1.7.14 and we only want to ship with it new patches applied.

This avoids creation of PRs like #28.